### PR TITLE
Make UTA PGD base URL configurable

### DIFF
--- a/misc/docker/load-uta.sh
+++ b/misc/docker/load-uta.sh
@@ -32,7 +32,7 @@ createdb   --username "$POSTGRES_USER" -O uta_admin uta
 # progress and pg restore progress.
 
 UTA_BASENAME=${UTA_VERSION}${UTA_SCHEMA_ONLY:+-schema}.pgd.gz
-UTA_PGD_URL=https://dl.biocommons.org/uta/${UTA_BASENAME}
+UTA_PGD_URL=${UTA_BASEURL}/${UTA_BASENAME}
 UTA_PGD_FN=/tmp/${UTA_BASENAME}
 
 if ! [ -e "${UTA_PGD_FN}" ]; then

--- a/misc/docker/uta.dockerfile
+++ b/misc/docker/uta.dockerfile
@@ -5,8 +5,10 @@ RUN apt-get update && apt-get install -y \
 
 # docker build --build-arg uta_version=uta_MYVERSION
 ARG uta_version=you-did-not-pass-a-build-arg
+ARG uta_baseurl=https://dl.biocommons.org/uta
 
 ENV UTA_VERSION=${uta_version}
+ENV UTA_BASEURL=${uta_baseurl}
 ENV PGDATA=/var/lib/postgresql/data/$UTA_VERSION
 LABEL description="PostgreSQL image with $UTA_VERSION installed (https://github.com/biocommons/uta/)"
 


### PR DESCRIPTION
We choose to self-host the UTA and NCBI PGD files we're using. I think this is a win-win. Biocommons saves on some bandwidth costs while we get to remove an external dependency from our build system. The downside to doing this is that we have to patch the `load-uta.sh` script to update `UTA_PGD_URL`. This update would make the base URL configurable. Hopefully others also find this useful.