### PR TITLE
Fix uta container search path

### DIFF
--- a/misc/docker/load-uta.sh
+++ b/misc/docker/load-uta.sh
@@ -9,7 +9,7 @@
 
 # Overwrite pg_hba.conf, including whatever edits might have been made
 # by the postgres image
-cat <<EOF >"$PGDATA/pg_hba.conf" 
+cat <<EOF >"$PGDATA/pg_hba.conf"
 # allow the anonymous user to access uta without password
 # These lines must occur before more stringent authentication methods
 host   all   anonymous     0.0.0.0/0      trust
@@ -50,7 +50,7 @@ gzip -cdq < "${UTA_PGD_FN}" \
 
 gzip -cdq < "${UTA_PGD_FN}" \
     | perl -n \
-	   -e 'm/CREATE SCHEMA (uta_\d+)/ && print("ALTER DATABASE :DBNAME SET search_path=$1;\n");' \
+	   -e 'm/CREATE SCHEMA (uta_[\d\w]+)/ && print("ALTER DATABASE :DBNAME SET search_path=$1;\n");' \
 	   -e 'print if s/CREATE MATERIALIZED VIEW (.\S+) AS/REFRESH MATERIALIZED VIEW $1;/' \
     | psql -1e -U uta_admin -d uta -v ON_ERROR_STOP=1
 
@@ -58,16 +58,16 @@ gzip -cdq < "${UTA_PGD_FN}" \
 cat <<EOF
 =======================================================================
 =======================================================================
-== 
+==
 == $UTA_VERSION installed from
 == $UTA_PGD_URL
-== 
+==
 == You may now connect to uta like this:
-== 
+==
 == $  psql -h localhost -p <port> -U anonymous -d uta
-== 
+==
 == No password is required.
-== 
+==
 =======================================================================
 =======================================================================
 


### PR DESCRIPTION
When the uta schema changed from `uta_20210129` to `uta_20210129b` it broke the regex used to discover the default search path in the loader script. This PR fixes that regex to include the `b`.