### PR TITLE
Fix setuptools>82 drop pkg_resources.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ package-data = {"sample" = ["*.dat"]}
 [build-system]
 requires = [
   "setuptools>=43.0.0",
+  "setuptools<82.0.0",
   "setuptools_scm==1.11.1",
   "wheel"
 ]


### PR DESCRIPTION
Setuptools>82 dropped pkg_resources, which will breaks the compile. check https://github.com/pypa/setuptools/issues/5174