### PR TITLE
Fix Docker build (Ubuntu 24.04 / PG17 / setuptools-scm) and restructure docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,31 @@
-FROM ubuntu:22.04 as uta
+FROM ubuntu:24.04 AS uta
 
 # set python version and define arguments
-ARG python_version="3.10"
+ARG python_version="3.12"
+
+# add PostgreSQL apt repository for postgresql-client-17
+RUN apt-get update && apt-get install -y curl ca-certificates \
+ && install -d /usr/share/postgresql-common/pgdg \
+ && curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+ && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt noble-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+ && apt-get clean
 
 # list and install dependencies
-ARG dependencies="python${python_version} python3-dev python3-pip rsync git postgresql-client-14 tabix"
+ARG dependencies="python${python_version} python3-dev python3-pip rsync git postgresql-client-17 tabix curl"
 
 RUN apt-get update && apt-get install -y $dependencies && apt-get clean
 
+# required on Ubuntu 24.04+ to allow pip to install packages system-wide in containers
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
 # install pysam, copy code, and run pip install
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN python -m pip install --upgrade pip
 RUN pip install --upgrade setuptools
 RUN pip install pysam
 
 WORKDIR /opt/repos/uta/
 COPY pyproject.toml ./
+COPY README.md ./
 COPY etc ./etc
 COPY misc ./misc
 COPY sbin ./sbin
@@ -24,7 +34,7 @@ RUN pip install -e .[dev]
 
 
 # UTA test image
-FROM uta as uta-test
+FROM uta AS uta-test
 RUN DEBIAN_FRONTEND=noninteractive apt-get -yq install postgresql
 COPY tests ./tests
 RUN pip install -e .[test]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ PostgreSQL access. (A [REST interface](https://github.com/biocommons/uta/issues/
 Users can access a public instance of UTA or build their own instance of
 the database.
 
+## Documentation
+
+This README covers accessing and installing UTA. Additional documentation lives
+in the [`docs/`](docs/) directory:
+
+- [Developer Setup](docs/development.md) — virtual environment, building the
+  Docker image, and running the tests.
+- [UTA update procedure](docs/updating-uta.md) — maintainer runbook for building
+  a new UTA/SeqRepo release (NCBI download, extract/transform, load, and SeqRepo
+  export).
+- [Migrations](docs/migrations.md) — managing database schema migrations with
+  alembic.
+
 ## Accessing the Public UTA Instance
 
 Invitae provides a public instance of UTA. The connection parameters
@@ -269,133 +282,3 @@ the installation environment.*
 
         $ uta_v=uta_20241220
         $ gzip -cdq $uta_v.pgd.gz | psql -U uta_admin -1 -v ON_ERROR_STOP=1 -d uta -Eae
-
-## Developer Setup
-
-### Virtual Environment
-To develop UTA, follow these steps.
-
-1.  Set up a virtual environment using your preferred method.
-    For example:
-
-        $ python3 -m venv uta-venv
-        $ source uta-venv/bin/activate
-
-2.  Clone UTA and install:
-
-        $ git clone git@github.com:biocommons/uta.git
-        $ cd uta
-        $ pip install -e .[test]
-
-3.  Restore a database or load a new one using the instructions [above](#installing-from-database-dumps).
-
-4.  To run the tests:
-
-        $ python3 -m unittest
-
-### Docker
-
-1. Clone UTA and build docker image:
-
-        $ git clone git@github.com:biocommons/uta.git
-        $ cd uta
-        $ docker build -t uta .
-
-2. Restore a database or load a new one using the instructions [above](#installing-from-database-dumps).
-
-3. Run container and tests
-
-        $ docker run -it --rm uta bash
-
-4. Testing
-
-        $ docker build --target uta-test -t uta-test .
-        $ docker run --rm uta-test python -m unittest
-
-## UTA update procedure
-
-Requires docker.
-
-### 0. Setup
-
-Make directories:
-```
-mkdir -p $(pwd)/ncbi-data
-mkdir -p $(pwd)/output/artifacts
-mkdir -p $(pwd)/output/logs
-```
-
-Set variables:
-```
-export UTA_ETL_OLD_UTA_IMAGE_TAG=uta_20240512
-export UTA_ETL_OLD_UTA_VERSION=UTA_ETL_OLD_UTA_IMAGE_TAG
-export UTA_ETL_NEW_UTA_VERSION=uta_20241220
-export UTA_ETL_NCBI_DIR=./ncbi-data
-export UTA_ETL_WORK_DIR=./output/artifacts
-export UTA_ETL_LOG_DIR=./output/logs
-```
-
-Build the UTA image:
-```
-docker build --target uta -t uta-update .
-```
-
-### 1. Download SeqRepo data
-```
-docker compose run seqrepo-pull
-```
-
-Note: pulling data takes ~30 minutes and requires ~13 GB.
-Note: a container called seqrepo will be left behind.
-
-### 2. Extract and transform data from NCBI
-
-Download files from NCBI, extract into intermediate files, and load into UTA and SeqRepo.
-
-See 2A for nuclear transcripts and 2B for mitochondrial transcripts.
-
-#### 2A. Nuclear transcripts
-```
-docker compose run ncbi-download
-docker compose run uta-extract
-docker compose run seqrepo-load
-docker compose run uta-load
-```
-
-#### 2B. Mitochondrial transcripts
-```
-docker compose -f docker-compose.yml -f misc/mito-transcripts/docker-compose-mito-extract.yml run mito-extract
-docker compose run seqrepo-load
-docker compose run uta-load
-```
-
-#### 2C. Manual splign transcripts
-To load splign-manual transcripts, the workflow expects an input txdata.yaml file and splign alignments. Define this path
-using the environment variable $UTA_SPLIGN_MANUAL_DIR. These file paths should exist:
-- `$UTA_SPLIGN_MANUAL_DIR/splign-manual/txdata.yaml`
-- `$UTA_SPLIGN_MANUAL_DIR/splign-manual/alignments/*.splign`
-
-[txdata.yaml](loading/data/splign-manual/txdata.yaml) defines the transcripts and their metadata. The [alignments dir](loading/data/splign-manual/alignments) contains the splign alignments.
-To run the workflow:
-```
-export UTA_SPLIGN_MANUAL_DIR=$(pwd)/loading/data/splign-manual/
-docker compose run splign-manual
-```
-
-UTA has updated and the database has been dumped into a pgd file in `UTA_ETL_WORK_DIR`. SeqRepo has been updated in place.
-
-
-## Migrations
-UTA uses alembic to manage database migrations. To auto-generate a migration:
-```
-alembic -c etc/alembic.ini revision --autogenerate -m "description of the migration"
-```
-This will create a migration script in the alembic/versions directory.
-Adjust the upgrade and downgrade function definitions. To apply the migration:
-```
-alembic -c etc/alembic.ini upgrade head
-```
-To reverse a migration, use `downgrade` with the number of steps to reverse. For example, to reverse the last:
-```
-alembic -c etc/alembic.ini downgrade -1
-```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,11 @@ services:
     image: biocommons/uta:${UTA_ETL_OLD_UTA_IMAGE_TAG}
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
+    volumes:
+      - type: bind
+        source: ./output/artifacts/${UTA_ETL_OLD_UTA_IMAGE_TAG}.pgd.gz
+        target: /tmp/${UTA_ETL_OLD_UTA_IMAGE_TAG}.pgd.gz
+        read_only: true
     healthcheck:
       test: psql -h localhost -U anonymous -d uta -c "select * from ${UTA_ETL_OLD_UTA_IMAGE_TAG}.meta"
       interval: 10s

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,47 @@
+# Developer Setup
+
+This guide covers setting up a local environment for developing UTA itself. If
+you only want to *use* UTA, see [Installing UTA Locally](../README.md#installing-uta-locally)
+in the main README instead.
+
+## Virtual Environment
+To develop UTA, follow these steps.
+
+1.  Set up a virtual environment using your preferred method.
+    For example:
+
+        $ python3 -m venv uta-venv
+        $ source uta-venv/bin/activate
+
+2.  Clone UTA and install:
+
+        $ git clone git@github.com:biocommons/uta.git
+        $ cd uta
+        $ pip install -e .[test]
+
+3.  Restore a database or load a new one using the instructions in
+    [Installing from database dumps](../README.md#installing-from-database-dumps).
+
+4.  To run the tests:
+
+        $ python3 -m unittest
+
+## Docker
+
+1. Clone UTA and build docker image:
+
+        $ git clone git@github.com:biocommons/uta.git
+        $ cd uta
+        $ docker build -t uta .
+
+2. Restore a database or load a new one using the instructions in
+   [Installing from database dumps](../README.md#installing-from-database-dumps).
+
+3. Run container and tests
+
+        $ docker run -it --rm uta bash
+
+4. Testing
+
+        $ docker build --target uta-test -t uta-test .
+        $ docker run --rm uta-test python -m unittest

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,14 @@
+# Migrations
+UTA uses alembic to manage database migrations. To auto-generate a migration:
+```
+alembic -c etc/alembic.ini revision --autogenerate -m "description of the migration"
+```
+This will create a migration script in the alembic/versions directory.
+Adjust the upgrade and downgrade function definitions. To apply the migration:
+```
+alembic -c etc/alembic.ini upgrade head
+```
+To reverse a migration, use `downgrade` with the number of steps to reverse. For example, to reverse the last:
+```
+alembic -c etc/alembic.ini downgrade -1
+```

--- a/docs/updating-uta.md
+++ b/docs/updating-uta.md
@@ -1,0 +1,183 @@
+# UTA update procedure
+
+This is the maintainer runbook for building a new UTA/SeqRepo release. It is not
+needed to install or use UTA — for that, see the [main README](../README.md).
+
+Requires docker.
+
+## 0. Setup
+
+Make directories:
+```
+mkdir -p $(pwd)/ncbi-data
+mkdir -p $(pwd)/output/artifacts
+mkdir -p $(pwd)/output/logs
+```
+
+Set variables:
+```
+export UTA_ETL_OLD_UTA_IMAGE_TAG=uta_20240512
+export UTA_ETL_OLD_UTA_VERSION=$UTA_ETL_OLD_UTA_IMAGE_TAG
+export UTA_ETL_NEW_UTA_VERSION=uta_20241220
+export UTA_ETL_NCBI_DIR=./ncbi-data
+export UTA_ETL_WORK_DIR=./output/artifacts
+export UTA_ETL_LOG_DIR=./output/logs
+```
+
+Provide the previous release's database snapshot. The `uta` service (which
+`uta-load` depends on) bind-mounts the prior UTA snapshot, so the file must
+exist before you run `uta-load`. Download `${UTA_ETL_OLD_UTA_IMAGE_TAG}.pgd.gz`
+from [dl.biocommons.org](https://dl.biocommons.org/uta/) and place it in the
+work directory:
+```
+# expected path: ./output/artifacts/${UTA_ETL_OLD_UTA_IMAGE_TAG}.pgd.gz
+```
+Note: this path is currently hardcoded to `./output/artifacts/` in
+`docker-compose.yml`, so `UTA_ETL_WORK_DIR` cannot be relocated without also
+editing that file.
+
+Build the UTA image:
+```
+docker build --target uta -t uta-update .
+```
+
+## 1. Download SeqRepo data
+```
+docker compose run seqrepo-pull
+```
+
+Note: pulling data takes ~30 minutes and requires ~13 GB.
+Note: a container called seqrepo will be left behind.
+
+## 2. Extract and transform data from NCBI
+
+Download files from NCBI, extract into intermediate files, and load the nuclear
+transcripts into UTA and SeqRepo:
+```
+docker compose run ncbi-download
+docker compose run uta-extract
+docker compose run seqrepo-load
+docker compose run uta-load
+```
+
+Note: `uta-load` depends on the `uta` service, which bind-mounts
+`./output/artifacts/${UTA_ETL_OLD_UTA_IMAGE_TAG}.pgd.gz`. Ensure that snapshot
+file is in place (see §0 Setup) or the step will fail to start.
+
+UTA has updated and the database has been dumped into a pgd file in `UTA_ETL_WORK_DIR`. SeqRepo has been updated in place.
+
+Loading mitochondrial or manual-splign transcripts is **not** part of the
+standard release process. If you need either, see
+[Non-standard steps](#non-standard-steps) below and run them after this section
+and before §3 (Export SeqRepo).
+
+## 3. Export SeqRepo
+
+The steps above leave the updated SeqRepo data inside the `uta_seqrepo-volume`
+Docker volume, not on the host. At this point the volume holds the previous
+SeqRepo version plus a writable `master` directory that accumulated the new
+sequences. To produce a distributable release you must snapshot `master` into a
+new dated version and copy it out of the volume, preserving hard links so that
+versions share storage instead of being duplicated.
+
+The commands below mount the SeqRepo volume at its default location
+(`/usr/local/share/seqrepo`) and bind `./output/seqrepo` on the host as the copy
+destination. Create that directory first if it does not exist:
+```
+mkdir -p $(pwd)/output/seqrepo
+```
+
+### 3A. Create a new snapshot
+
+Start a container with the SeqRepo volume mounted and snapshot `master` into a
+new version. By convention the snapshot name is the new UTA version's release
+date in `YYYY-MM-DD` form (e.g. `uta_20241220` -> `2024-12-20`):
+```
+docker run -it --rm --name uta-build \
+  --volume $(pwd):/opt/repos/uta \
+  --volume uta_seqrepo-volume:/usr/local/share/seqrepo \
+  --volume $(pwd)/output/seqrepo:/seqrepo_data \
+  --network=host uta-update:latest
+
+# inside the container:
+seqrepo snapshot --destination-name "2024-12-20"
+```
+
+### 3B. Copy SeqRepo out of the Docker volume
+
+The snapshot still lives inside the volume. Copy it out to the host destination
+(`/seqrepo_data`, bound to `./output/seqrepo`). Use `rsync -H` so hard links
+between versions are preserved.
+
+The files inside the volume are owned by the container's user. If your target
+environment expects specific ownership or permissions, set them before copying.
+The `useradd`/`groupadd`/`chown` lines below are an illustrative example —
+replace the uid, gid, and names with values appropriate for your systems, or
+omit these lines entirely if the defaults are acceptable:
+```
+docker run -it --rm --name uta-build \
+  --volume $(pwd):/opt/repos/uta \
+  --volume uta_seqrepo-volume:/usr/local/share/seqrepo \
+  --volume $(pwd)/output/seqrepo:/seqrepo_data \
+  --network=host uta-update:latest
+
+# inside the container:
+# (optional) align ownership/permissions with your destination environment
+useradd -u 1000 seqrepo_user
+groupadd -g 1000 seqrepo_group
+cd /usr/local/share/seqrepo
+chown -R seqrepo_user:seqrepo_group *
+find . -type d -exec chmod 755 {} +
+
+# copy out of the volume, preserving hard links (-H)
+cd /usr/local/share
+rsync -avzPH seqrepo/ /seqrepo_data/
+```
+
+The exported SeqRepo release now lives in `./output/seqrepo` on the host.
+
+### 3C. Publish to a SeqRepo location using hard links
+
+When placing the new version alongside existing versions at a destination, use
+`rsync --link-dest` pointing at the *previous* version so that unchanged
+sequence files are hard-linked rather than duplicated. The trailing slashes are
+significant:
+```
+cd output/seqrepo
+# --link-dest is the previous version, given relative to the destination
+rsync -aP --link-dest=../2024-05-23/ 2024-12-20/ <destination>/seqrepo/2024-12-20/
+```
+
+## Non-standard steps
+
+The steps below are **not** part of the standard nuclear-transcript release
+process. When one is needed, run it after §2 (Extract and transform) and before
+§3 (Export SeqRepo) — each loads additional sequences into SeqRepo and dumps a
+new UTA pgd file, so it must complete before the SeqRepo snapshot is taken.
+
+### Mitochondrial transcripts
+
+Mitochondrial transcripts were loaded as a one-time process for the May 2025
+release. This is documented for reference and is not expected to be part of
+routine updates.
+```
+docker compose -f docker-compose.yml -f misc/mito-transcripts/docker-compose-mito-extract.yml run mito-extract
+docker compose run seqrepo-load
+docker compose run uta-load
+```
+
+### Manual splign transcripts
+
+This is a special case for loading user-provided transcript alignments instead
+of the standard NCBI-derived ones. The workflow expects an input `txdata.yaml`
+file and splign alignments. Define their location with the
+`UTA_SPLIGN_MANUAL_DIR` environment variable. These paths must exist:
+- `$UTA_SPLIGN_MANUAL_DIR/splign-manual/txdata.yaml`
+- `$UTA_SPLIGN_MANUAL_DIR/splign-manual/alignments/*.splign`
+
+[txdata.yaml](../loading/data/splign-manual/txdata.yaml) defines the transcripts and their metadata. The [alignments dir](../loading/data/splign-manual/alignments) contains the splign alignments.
+To run the workflow:
+```
+export UTA_SPLIGN_MANUAL_DIR=$(pwd)/loading/data/splign-manual/
+docker compose -f docker-compose.yml -f misc/splign-manual/docker-compose-splign-manual.yml run splign-manual
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ package-data = {"sample" = ["*.dat"]}
 [build-system]
 requires = [
   "setuptools>=43.0.0",
-  "setuptools_scm==1.11.1",
+  "setuptools_scm>=7.0",
   "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/sbin/fasta-to-seqinfo
+++ b/sbin/fasta-to-seqinfo
@@ -5,9 +5,9 @@
 import argparse
 import gzip
 import logging
+import importlib.resources
 import logging.config
 import os
-import pkg_resources
 import re
 import sys
 
@@ -70,8 +70,7 @@ def process1(opts, siw, fn):
 
 
 if __name__ == "__main__":
-    logging_conf_fn = pkg_resources.resource_filename(
-        "uta", "etc/logging.conf")
+    logging_conf_fn = str(importlib.resources.files("uta").joinpath("etc/logging.conf"))
     logging.config.fileConfig(logging_conf_fn)
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)

--- a/sbin/ncbi-download
+++ b/sbin/ncbi-download
@@ -17,13 +17,25 @@ else
     echo "Downloading files to $DOWNLOAD_DIR"
 fi
 
+# Top-level modules available on NCBI's rsync daemon (ftp.ncbi.nlm.nih.gov::)
+RSYNC_MODULES="1000genomes bigwig bioproject biosample blast cgap cn3d comparative-genome-viewer dbgap entrez epigenomics fa2htgs genbank gene hapmap hmm mmdb ncbi-asn1 osiris pathogen pubchem pubmed rapt ReferenceSamples refseq repository sequin sky-cgh snp sra tech-reports toolbox tpa tracedb variation"
+
 grep -v -e '^#' -e '^$' "$FILE_PATH_CONFIG" | while read -r DOWNLOAD_PATH; do
     # each top-level directory in NCBI is an rsync module.
     # bash parameter expansion removes all content after first slash.
     DOWNLOAD_MODULE="${DOWNLOAD_PATH%%/*}"
-    DOWNLOAD_SRC="ftp.ncbi.nlm.nih.gov::$DOWNLOAD_PATH"
-    DOWNLOAD_DST="$DOWNLOAD_DIR/$DOWNLOAD_MODULE"
-    mkdir -p $DOWNLOAD_DST
-    echo "Downloading $DOWNLOAD_SRC to $DOWNLOAD_DST"
-    rsync --no-motd -DHPRprtv "$DOWNLOAD_SRC" "$DOWNLOAD_DST"
+
+    if echo "$RSYNC_MODULES" | grep -qw "$DOWNLOAD_MODULE"; then
+        DOWNLOAD_SRC="ftp.ncbi.nlm.nih.gov::$DOWNLOAD_PATH"
+        DOWNLOAD_DST="$DOWNLOAD_DIR/$DOWNLOAD_MODULE"
+        mkdir -p "$DOWNLOAD_DST"
+        echo "Downloading $DOWNLOAD_SRC to $DOWNLOAD_DST"
+        rsync --no-motd -DHPRprtv "$DOWNLOAD_SRC" "$DOWNLOAD_DST"
+    else
+        DOWNLOAD_SRC="https://ftp.ncbi.nlm.nih.gov/$DOWNLOAD_PATH"
+        DOWNLOAD_DST="$DOWNLOAD_DIR/$DOWNLOAD_PATH"
+        mkdir -p "$(dirname "$DOWNLOAD_DST")"
+        echo "Downloading $DOWNLOAD_SRC to $DOWNLOAD_DST"
+        curl -fSL --progress-bar -o "$DOWNLOAD_DST" "$DOWNLOAD_SRC"
+    fi
 done

--- a/sbin/ncbi-parse-gbff
+++ b/sbin/ncbi-parse-gbff
@@ -25,7 +25,6 @@ NM_138933.2 NC_000010.10    splign  -1  52645340,52645435;52...
 from __future__ import division, unicode_literals
 
 import argparse
-from collections import Counter
 import gzip
 import importlib_resources
 import io
@@ -35,7 +34,6 @@ import re
 import sys
 
 import Bio.SeqIO
-from bioutils.digests import seq_md5
 
 from uta.formats.txinfo import TxInfo, TxInfoWriter
 from uta.parsers.seqrecord import SeqRecordFacade, SeqRecordFeatureError
@@ -56,20 +54,6 @@ def parse_args(argv):
                     default="ncbi-gbff")
     opts = ap.parse_args(argv)
     return opts
-
-
-def gbff_filter(it):
-    """pre-filter genbank file stream for records that match a specific LOCUS pattern"""
-    delim = "//"
-    emit = False
-    locus_re = re.compile(r'LOCUS\s+N[MR]')
-    for line in it:
-        if line.startswith("LOCUS") and locus_re.match(line):
-            emit = True
-        if emit:
-            yield line
-            if line.startswith(delim):
-                emit = False
 
 
 def gbff_block_reader(it):
@@ -99,18 +83,11 @@ if __name__ == "__main__":
     tiw = TxInfoWriter(sys.stdout)
 
     total_genes = set()
-    skipped_ids = set()
-    all_prefixes = Counter()
     for fn in opts.GBFF_FILES:
         flo = gzip.open(fn, "rt")
         logger.info("opened " + fn)
         genes = set()
-        prefixes = Counter()
-        for srf in (SeqRecordFacade(r) for r in Bio.SeqIO.parse(flo, "gb")):
-            prefixes.update([srf.id[:2]])
-            if srf.id.partition("_")[0] not in ["NM", "NR"]:
-                skipped_ids.add(srf.id)
-                continue
+        for srf in gbff_block_reader(flo):
             ti = TxInfo(
                 ac=srf.id,
                 origin=opts.origin,
@@ -123,8 +100,7 @@ if __name__ == "__main__":
             )
             tiw.write(ti)
             genes.add(srf.gene_symbol)
-        logger.info("{ng} genes in {fn} ({c})".format(ng=len(genes), fn=fn, c=prefixes))
+        logger.info("{ng} genes in {fn}".format(ng=len(genes), fn=fn))
         total_genes ^= genes
-        all_prefixes += prefixes
-    logger.info("{ng} genes in {nf} files ({c})".format(
-        ng=len(total_genes), nf=len(opts.GBFF_FILES), c=all_prefixes))
+    logger.info("{ng} genes in {nf} files".format(
+        ng=len(total_genes), nf=len(opts.GBFF_FILES)))

--- a/src/uta/__init__.py
+++ b/src/uta/__init__.py
@@ -1,7 +1,7 @@
-import pkg_resources
 import logging
 import os
 import warnings
+from importlib.metadata import version, PackageNotFoundError
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -11,8 +11,8 @@ from uta import models
 
 
 try:
-    __version__ = pkg_resources.get_distribution(__package__).version
-except pkg_resources.DistributionNotFound as e:
+    __version__ = version(__package__)
+except PackageNotFoundError:
     warnings.warn(
         "can't get __version__ because %s package isn't installed" % __package__, Warning)
     __version__ = None

--- a/src/uta/cli.py
+++ b/src/uta/cli.py
@@ -49,7 +49,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import configparser
 import logging
 import logging.config
-import pkg_resources
 import time
 
 import docopt
@@ -87,11 +86,6 @@ def main():
 
     opts = docopt.docopt(__doc__, version=uta.__version__)
 
-    #logging_conf_fn = pkg_resources.resource_filename("uta", "etc/logging.conf")
-    #logging.config.fileConfig(logging_conf_fn)
-    #verbose_log_level = logging.INFO # if opts.verbose == 0 else logging.INFO if opts.verbose == 1 else logging.DEBUG
-    #logger.setLevel(level=verbose_log_level)
-
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
 
@@ -101,7 +95,7 @@ def main():
     cf_loaded = dict()
     for conf_fn in opts["--conf"]:
         if conf_fn not in cf_loaded:
-            cf.readfp(open(conf_fn))
+            cf.read_file(open(conf_fn))
             cf_loaded[conf_fn] = True
             logger.info("loaded " + conf_fn)
 

--- a/tests/test_uta_loading.py
+++ b/tests/test_uta_loading.py
@@ -390,11 +390,14 @@ class TestUtaLoading(unittest.TestCase):
         ), patch("uta.loading.logger") as mock_logger:
             ul.load_exonset(self.session, {"FILE": "tests/data/exonsets.mm-exons.gz"}, cf)
 
-            assert mock_logger.warning.called_with(
+            logged = [str(call.args[0]) for call in mock_logger.exception.call_args_list]
+            assert (
                 "Exon structure mismatch: 4 exons in transcript NM_001005484.2; 3 in alignment NC_000001.11"
+                in logged
             )
-            assert mock_logger.warning.called_with(
+            assert (
                 "Exon structure mismatch: 1 exons in transcript NM_000864.5; 2 in alignment NC_000001.11"
+                in logged
             )
 
         # check that the exons for NM_000864.5 and NM_001005484.2 were not loaded,


### PR DESCRIPTION
  Body:
  ## Summary
  - Upgrade build environment to Ubuntu 24.04, Python 3.12, PostgreSQL 17, and fix the setuptools-scm Docker build failure
  - Replace deprecated pkg_resources with importlib stdlib equivalents
  - Fall back to curl for NCBI paths that are not valid rsync modules
  - Simplify ncbi-parse-gbff by removing the NM/NR pre-filter
  - Split the README into docs/ (development, update runbook, migrations), document the SeqRepo export/snapshot/publish steps, and move mito/manual-splign loads into a "Non-standard steps" section

  ## Notes
  - Documents the new `uta` service snapshot bind-mount prerequisite and fixes a `$UTA_ETL_OLD_UTA_IMAGE_TAG` typo in the update procedure